### PR TITLE
Fixed package install failing when run as non-root

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 ---
 namespace: dandyrow
 name: iac
-version: 1.1.0
+version: 1.1.1
 readme: README.md
 authors:
   - Daniel Lowry (github.com/dandyrow)

--- a/roles/stow_dotfiles/tasks/main.yml
+++ b/roles/stow_dotfiles/tasks/main.yml
@@ -5,6 +5,8 @@
   when: ansible_os_family == "Debian"
 
 - name: Ensure required packages are installed
+  become: true
+  become_user: root
   ansible.builtin.package:
     name: "{{ required_packages }}"
     state: present


### PR DESCRIPTION
When role wasn't run as root user checking the required packages were installed would fail as it required root privileges.