### PR TITLE
Changed name of collection to dandyrow.linux

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install collection locally
         run: >
           ansible-galaxy collection install
-          dandyrow-iac-$(grep version galaxy.yml | awk '{print $2}').tar.gz
+          dandyrow-linux-$(grep version galaxy.yml | awk '{print $2}').tar.gz
 
       - name: Install sphinx dependencies
         run: pip3 install -r docs/requirements.txt
@@ -39,11 +39,11 @@ jobs:
       - name: Build intermediate rst files
         run: >
           antsibull-docs collection --use-current
-          --dest-dir docs dandyrow.iac
+          --dest-dir docs dandyrow.linux
 
       - name: Build docsite
         run: >
-          sphinx-build -M html docs/collections/dandyrow/iac
+          sphinx-build -M html docs/collections/dandyrow/linux
           docs/build -c docs -W --keep-going
 
       - name: Upload pages artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
   #     - name: Checkout source
   #       uses: actions/checkout@v3
   #       with:
-  #         path: ansible_collections/dandyrow/iac
+  #         path: ansible_collections/dandyrow/linux
 
   #     - name: Set version number to tag name
-  #       working-directory: ansible_collections/dandyrow/iac
+  #       working-directory: ansible_collections/dandyrow/linux
   #       run: >
   #         "sed -E -i 's/(version: ).*/\\1${{ github.ref_name }}/g' galaxy.yml"
 
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
         with:
-          path: ansible_collections/dandyrow/iac
+          path: ansible_collections/dandyrow/linux
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -46,15 +46,15 @@ jobs:
         run: pip3 install ansible-core
 
       - name: Build collection tarball
-        working-directory: ansible_collections/dandyrow/iac
+        working-directory: ansible_collections/dandyrow/linux
         run: ansible-galaxy collection build
 
       - name: Upload collection build
         uses: actions/upload-artifact@v3
         with:
           name: collection_tarball
-          path: "ansible_collections/dandyrow/iac/\
-            dandyrow-iac-${{ github.ref_name }}.tar.gz"
+          path: "ansible_collections/dandyrow/linux/\
+            dandyrow-linux-${{ github.ref_name }}.tar.gz"
           if-no-files-found: error
           retention-days: 1
 
@@ -79,4 +79,4 @@ jobs:
         run: >
           ansible-galaxy collection publish
           --token ${{ secrets.GALAXY_API_KEY }} -v
-          dandyrow-iac-${{ github.ref_name }}.tar.gz
+          dandyrow-linux-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
         with:
-          path: ansible_collections/dandyrow/iac
+          path: ansible_collections/dandyrow/linux
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -187,7 +187,7 @@ jobs:
           ansible-lint "molecule-plugins[podman]" podman
 
       - name: Run Molecule tests.
-        working-directory: ansible_collections/dandyrow/iac/tests/integration
+        working-directory: ansible_collections/dandyrow/linux/tests/integration
         run: molecule test --all
         env:
           MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We are actively accepting new contributors.
 
 Any kind of contribution is very welcome, whether it be adding support for another Linux distro, fixing a bug or improving documentation.
 
-Discussions regarding contributions and their impact on the wider project will be conducted in the [issue tracker](https://github.com/dandyrow/dandyrow.iac/actions) on the collection's GitHub repo.
+Discussions regarding contributions and their impact on the wider project will be conducted in the [issue tracker](https://github.com/dandyrow/dandyrow.linux/actions) on the collection's GitHub repo.
 
 The final say on any contributions to this collection will be made by me (dandyrow) following a discussion about the contribution and the wider implications it has on the project's goals. Having said that I am very open to all improvements anyone wishes to make.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Dandyrow's infrastructure as code collection for Ansible
 
-[![Test Collection](https://github.com/dandyrow/dandyrow.iac/actions/workflows/test.yml/badge.svg)](https://github.com/dandyrow/dandyrow.iac/actions/workflows/test.yml)
+[![Test Collection](https://github.com/dandyrow/dandyrow.linux/actions/workflows/test.yml/badge.svg)](https://github.com/dandyrow/dandyrow.linux/actions/workflows/test.yml)
 
-iac = infrastructure as code
+linux = infrastructure as code
 
 This collection contains modules and roles relating to my project to define my homelab infrastructure as code to allow quicker disaster recovery and consistent environments to be created.
 
 A key module contained within this collection is the stow module. This allows Ansible to interact with the GNU stow utility. This is useful for installing dotfiles which have been organised into packages which can be expanded with said utility.
 
-https://github.com/dandyrow/dandyrow.iac
+https://github.com/dandyrow/dandyrow.linux
 
 ## Contributing to this collection
 
@@ -18,7 +18,7 @@ We are actively accepting new contributors.
 
 Any kind of contribution is very welcome.
 
-If you would like to contribute please read the information in the [CONTRIBUTING](https://github.com/dandyrow/dandyrow.iac/blob/main/CONTRIBUTING.md) file.
+If you would like to contribute please read the information in the [CONTRIBUTING](https://github.com/dandyrow/dandyrow.linux/blob/main/CONTRIBUTING.md) file.
 
 ## Governance
 
@@ -35,7 +35,7 @@ The stow module found within this collection relies on the GNU stow utility bein
 
 ## Included content
 
-Content included within this collection can be found within the [documentation](https://dandyrow.github.io/dandyrow.iac/).
+Content included within this collection can be found within the [documentation](https://dandyrow.github.io/dandyrow.linux/).
 
 ## Using this collection
 
@@ -43,41 +43,41 @@ Content included within this collection can be found within the [documentation](
 
 Before using this collection, you need to install it with the Ansible Galaxy command-line tool:
 ```bash
-ansible-galaxy collection install dandyrow.iac
+ansible-galaxy collection install dandyrow.linux
 ```
 
 You can also include it in a `requirements.yml` file and install it with `ansible-galaxy collection install -r requirements.yml`, using the format:
 ```yaml
 ---
 collections:
-  - name: dandyrow.iac
+  - name: dandyrow.linux
 ```
 
 Note that if you install the collection from Ansible Galaxy, it will not be upgraded automatically when you upgrade the `ansible` package. To upgrade the collection to the latest available version, run the following command:
 ```bash
-ansible-galaxy collection install dandyrow.iac --upgrade
+ansible-galaxy collection install dandyrow.linux --upgrade
 ```
 
 You can also install a specific version of the collection, for example, if you need to downgrade when something is broken in the latest version (please report an issue in this repository). Use the following syntax to install version `0.1.0`:
 
 ```bash
-ansible-galaxy collection install dandyrow.iac:==0.1.0
+ansible-galaxy collection install dandyrow.linux:==0.1.0
 ```
 
 See [Ansible Using collections](https://docs.ansible.com/ansible/devel/user_guide/collections_using.html) for more details.
 
 ### Using the contents of this collection
 
-Documentation on using the contents of this collection can be found on the collection's [docsite](https://dandyrow.github.io/dandyrow.iac/).
+Documentation on using the contents of this collection can be found on the collection's [docsite](https://dandyrow.github.io/dandyrow.linux/).
 
 ## Release notes
 
-See the release notes on the [GitHub releases page](https://github.com/dandyrow/dandyrow.iac/releases).
+See the release notes on the [GitHub releases page](https://github.com/dandyrow/dandyrow.linux/releases).
 
 ## More information
 
-- [dandyrow.iac Collection Documentation](https://dandyrow.github.io/dandyrow.iac)
-- [Collection's Ansible Galaxy Page](https://galaxy.ansible.com/dandyrow/iac)
+- [dandyrow.linux Collection Documentation](https://dandyrow.github.io/dandyrow.linux)
+- [Collection's Ansible Galaxy Page](https://galaxy.ansible.com/dandyrow/linux)
 - [Ansible Collection overview](https://github.com/ansible-collections/overview)
 - [Ansible User guide](https://docs.ansible.com/ansible/devel/user_guide/index.html)
 - [Ansible Developer guide](https://docs.ansible.com/ansible/devel/dev_guide/index.html)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,11 +6,11 @@
 # documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-project = 'dandyrow.iac Ansible collection'
+project = 'dandyrow.linux Ansible collection'
 copyright = 'Daniel Lowry'
 
-title = 'dandyrow.iac Ansible Collection Documentation'
-html_short_title = 'dandyrow.iac Documentation'
+title = 'dandyrow.linux Ansible Collection Documentation'
+html_short_title = 'dandyrow.linux Documentation'
 
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx_antsibull_ext']
 

--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -1,5 +1,5 @@
 ---
 edit_on_github:
-  repository: dandyrow/dandyrow.iac
+  repository: dandyrow/dandyrow.linux
   branch: main
   path_prefix: ''

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 # https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
 ---
 namespace: dandyrow
-name: iac
+name: linux
 version: 1.1.1
 readme: README.md
 authors:
@@ -13,9 +13,9 @@ tags:
   - linux
   - stow
   - infrastructure
-repository: https://github.com/dandyrow/dandyrow.iac
-documentation: https://dandyrow.github.io/dandyrow.iac
-homepage: https://dandyrow.github.io/dandyrow.iac
-issues: https://github.com/dandyrow/dandyrow.iac/issues
+repository: https://github.com/dandyrow/dandyrow.linux
+documentation: https://dandyrow.github.io/dandyrow.linux
+homepage: https://dandyrow.github.io/dandyrow.linux
+issues: https://github.com/dandyrow/dandyrow.linux/issues
 build_ignore:
   - .gitignore

--- a/roles/stow_dotfiles/README.md
+++ b/roles/stow_dotfiles/README.md
@@ -34,7 +34,7 @@ The following variable can be found in vars/main.yml:
 Dependencies
 ------------
 
-This role is part of and depends on the [dandyrow.iac collection.](https://github.com/dandyrow/dandyrow.iac)
+This role is part of and depends on the [dandyrow.linux collection.](https://github.com/dandyrow/dandyrow.linux)
 
 Example Playbook
 ----------------

--- a/roles/stow_dotfiles/tasks/main.yml
+++ b/roles/stow_dotfiles/tasks/main.yml
@@ -19,7 +19,7 @@
     version: "{{ dotfiles_repo_branch }}"
 
 - name: Stow packages into {{ dotfiles_target_path }}
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ dotfiles_local_repo }}"
     dest: "{{ dotfiles_target_path }}"
     package: "{{ dotfiles_to_install }}"

--- a/tests/integration/molecule/stow_dotfiles/converge.yml
+++ b/tests/integration/molecule/stow_dotfiles/converge.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   roles:
-    - role: dandyrow.iac.stow_dotfiles
+    - role: dandyrow.linux.stow_dotfiles
       vars:
         dotfiles_remote_repo: https://github.com/dandyrow/dotfiles.git
         dotfiles_to_install:

--- a/tests/integration/targets/stow/tasks/test_check_mode.yml
+++ b/tests/integration/targets/stow/tasks/test_check_mode.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run stow module in check mode
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ source_dir }}"
     dest: "{{ target_dir }}"
     package:

--- a/tests/integration/targets/stow/tasks/test_param_validation.yml
+++ b/tests/integration/targets/stow/tasks/test_param_validation.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test failure when source directory doesn't exist
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: /path/doesnt/exist
     package:
       - zsh
@@ -14,7 +14,7 @@
       - "'does not exist' in source_fail.msg"
 
 - name: Test failure when target directory doesn't exist
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ source_dir }}"
     dest: /path/doesnt/exist
     package:

--- a/tests/integration/targets/stow/tasks/test_stow_execution.yml
+++ b/tests/integration/targets/stow/tasks/test_stow_execution.yml
@@ -1,6 +1,6 @@
 ---
 - name: Stow nvim config files
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ source_dir }}"
     dest: "{{ target_dir }}"
     package: ['nvim']
@@ -23,7 +23,7 @@
     - "{{ target_dir }}/plugin.lua"
 
 - name: Stow nvim config files
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ source_dir }}"
     dest: "{{ target_dir }}"
     package: ['nvim']
@@ -41,7 +41,7 @@
     state: touch
 
 - name: Stow zsh config file
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ source_dir }}"
     dest: "{{ target_dir }}"
     package: ["zsh"]
@@ -62,7 +62,7 @@
     state: directory
 
 - name: Stow zsh config file
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ source_dir }}"
     dest: "{{ target_dir }}"
     package: ["zsh"]
@@ -78,7 +78,7 @@
         .dotfiles/zsh/.zprofile' in directory_conflict.stderr"
 
 - name: Stow zsh config file
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ source_dir }}"
     dest: "{{ target_dir }}"
     package: ["zsh"]
@@ -100,7 +100,7 @@
     state: absent
 
 - name: Force stow zsh
-  dandyrow.iac.stow:
+  dandyrow.linux.stow:
     src: "{{ source_dir }}"
     dest: "{{ target_dir }}"
     package: ["zsh"]

--- a/tests/unit/plugins/modules/test_stow.py
+++ b/tests/unit/plugins/modules/test_stow.py
@@ -26,7 +26,7 @@ from unittest import TestCase, main
 from ansible.module_utils import basic
 # from ansible.module_utils.compat import typing
 from ansible.module_utils.common.text.converters import to_bytes
-from ansible_collections.dandyrow.iac.plugins.modules import stow
+from ansible_collections.dandyrow.linux.plugins.modules import stow
 try:
     from unittest.mock import patch
 except ImportError:
@@ -208,7 +208,7 @@ class TestDirValidation(TestCase):
         """Return True if path is /this/path/exists otherwise return False"""
         return path == '/this/path/exists' or path == '/etc'
 
-    @patch('ansible_collections.dandyrow.iac.plugins.modules.stow.os.path')
+    @patch('ansible_collections.dandyrow.linux.plugins.modules.stow.os.path')
     def test_dir_not_exist(self, mock_path):
         """Tests passed in function called if one of passed in directories doesn't exist"""
         mock_path.isdir = self.isdir
@@ -217,7 +217,7 @@ class TestDirValidation(TestCase):
         actual_result = stow.validate_directories(['test', 'folder'])
         self.assertEqual(expected_result, actual_result)
 
-    @patch('ansible_collections.dandyrow.iac.plugins.modules.stow.os.path')
+    @patch('ansible_collections.dandyrow.linux.plugins.modules.stow.os.path')
     def test_dir_exists(self, mock_path):
         """Tests that nothing happens if all directories exist"""
         mock_path.isdir = self.isdir


### PR DESCRIPTION
This commit changes the name of the collection everywhere in the collection from dandyrow.iac to dandyrow.linux to better reflect the contents of the collection.