### PR TITLE
Systemd role fixes

### DIFF
--- a/roles/systemd_boot/templates/entry.j2
+++ b/roles/systemd_boot/templates/entry.j2
@@ -3,3 +3,4 @@ title {{ entry_title }}
 linux /vmlinuz-linux
 initrd /initramfs-linux.img
 options root=UUID={{ root_partition_uuid.stdout_lines[0] }} rw
+

--- a/roles/systemd_networkd/tasks/main.yml
+++ b/roles/systemd_networkd/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Copy basic wired network config
-  ansible.builtin.copy:
+  ansible.builtin.template:
     src: "{{ role_path }}/templates/20-wired.j2"
     dest: /etc/systemd/network/20-wired.network
     owner: root

--- a/tests/integration/molecule/systemd_networkd/20-wired.network
+++ b/tests/integration/molecule/systemd_networkd/20-wired.network
@@ -1,0 +1,5 @@
+[Match]
+Name=en*
+
+[Network]
+DHCP=yes

--- a/tests/integration/molecule/systemd_networkd/verify.yml
+++ b/tests/integration/molecule/systemd_networkd/verify.yml
@@ -1,0 +1,20 @@
+---
+- name: Verify wired config transferred correctly
+  hosts: all
+  tasks:
+    - name: Read expected file
+      ansible.builtin.slurp:
+        src: ./20-wired.network
+      register: expected
+      delegate_to: localhost
+
+    - name: Read actual file
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/20-wired.network
+      register: actual
+
+    - name: Compare file content
+      ansible.builtin.assert:
+        that: expected.content == actual.content
+        success_msg: Expected and actual wired config files match.
+        fail_msg: Expected and actual wired config files don't match.


### PR DESCRIPTION
- Fixed an issue with systemd_networkd role where the template file was being copied across instead of being used to create a file on the remote system.