### PR TITLE
Remove tests for unsupported python versions w/ devel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
           - '3.9'
           - '3.10'
         exclude:
-          # Python 2.7 and 3.6 no longer supported with devel prior to 2.16 release
+        # Python 2.7 & 3.6 no longer supported with devel prior to 2.16 release
           - ansible: devel
             python: '2.7'
           - ansible: devel
@@ -140,8 +140,8 @@ jobs:
           - '3.9'
           - '3.10'
         exclude:
-          # Python 2.6 is not supported with ansible-core >= 2.13
-          # Python 2.7 and 3.6 no longer supported with devel prior to 2.16 release
+        # Python 2.6 is not supported with ansible-core >= 2.13
+        # Python 2.7 & 3.6 no longer supported with devel prior to 2.16 release
           - ansible: stable-2.13
             python: '2.6'
           - ansible: stable-2.14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,12 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+        exclude:
+          # Python 2.7 and 3.6 no longer supported with devel prior to 2.16 release
+          - ansible: devel
+            python: '2.7'
+          - ansible: devel
+            python: '3.6'
 
     steps:
       - name: >-
@@ -135,6 +141,7 @@ jobs:
           - '3.10'
         exclude:
           # Python 2.6 is not supported with ansible-core >= 2.13
+          # Python 2.7 and 3.6 no longer supported with devel prior to 2.16 release
           - ansible: stable-2.13
             python: '2.6'
           - ansible: stable-2.14
@@ -143,6 +150,10 @@ jobs:
             python: '2.6'
           - ansible: devel
             python: '2.6'
+          - ansible: devel
+            python: '2.7'
+          - ansible: devel
+            python: '3.6'
 
     steps:
       - name: >-


### PR DESCRIPTION
Devel dropped support for python 2.7 and 3.6 with ansible-test. This has been causing the unit and integration tests to fail for the past few weeks on this repo. This commit aims to remedy that.